### PR TITLE
Stories android travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,7 @@ matrix:
       script:
         - cd $TRAVIS_BUILD_DIR/android-app/
         - ./gradlew build jacocoTestReport assembleAndroidTest
-        - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-        - emulator -avd test -no-skin -no-audio -no-window &
-        - android-wait-for-emulator
-        - adb shell setprop dalvik.vm.dexopt-flags v=n,o=v
-        - ./gradlew connectedCheck
+        - ./gradlew test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: android
 env:
   global:
     - ANDROID_TARGET=android-15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: python
+env:
+  global:
+    - ANDROID_TARGET=android-15
+    - ANDROID_ABI=armeabi-v7a
+android:
+  components:
+  - tools
+  - platform-tools
+  - build-tools-26.0.2
+  - android-26
+  - extra-android-m2repository
+  - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
 python:
   - "3.6"
 node_js:
@@ -9,16 +21,30 @@ before_install:
   - pip install pytest pytest-cov
   - pip install codecov
 install:
+  #app server
   - cd $TRAVIS_BUILD_DIR/application-server/ && pip install -r requirements.txt
+  #shared server
   - cd $TRAVIS_BUILD_DIR/shared-server/ && npm install
   - npm install -g istanbul
   - npm install -g codecov
 script:
+  #shared server
   - cd $TRAVIS_BUILD_DIR/shared-server/ && npm test
   - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec
   - codecov
-  - cd $TRAVIS_BUILD_DIR/application-server/ 
+  #app server
+  - cd $TRAVIS_BUILD_DIR/application-server/
   - export MONGO_URI=mongodb://localhost:27017/appserverdb
   - python app.py &
   - cd $TRAVIS_BUILD_DIR/application-server/test/ && pytest --cov=./
   - codecov
+  #android app
+  - cd $TRAVIS_BUILD_DIR/android-app/
+  - ./gradlew build jacocoTestReport assembleAndroidTest
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell setprop dalvik.vm.dexopt-flags v=n,o=v
+  - ./gradlew connectedCheck
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - language: android
       jdk: oraclejdk8
       env:
-        - ANDROID_TARGET=android-15
+        - ANDROID_TARGET=android-26
         - ANDROID_ABI=armeabi-v7a
       android:
         components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
         - platform-tools
         - build-tools-26.0.2
         - android-26
-        - android-22
         - extra-android-m2repository
         - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,55 @@
-language: android
-env:
-  global:
-    - ANDROID_TARGET=android-15
-    - ANDROID_ABI=armeabi-v7a
-android:
-  components:
-  - tools
-  - platform-tools
-  - build-tools-26.0.2
-  - android-26
-  - extra-android-m2repository
-  - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
-python:
-  - "3.6"
-node_js:
-  - "8.10"
-services:
-  - mongodb
-before_install:
-  - pip install pytest pytest-cov
-  - pip install codecov
-install:
-  #app server
-  - cd $TRAVIS_BUILD_DIR/application-server/ && pip install -r requirements.txt
-  #shared server
-  - cd $TRAVIS_BUILD_DIR/shared-server/ && npm install
-  - npm install -g istanbul
-  - npm install -g codecov
-script:
-  #shared server
-  - cd $TRAVIS_BUILD_DIR/shared-server/ && npm test
-  - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec
-  - codecov
-  #app server
-  - cd $TRAVIS_BUILD_DIR/application-server/
-  - export MONGO_URI=mongodb://localhost:27017/appserverdb
-  - python app.py &
-  - cd $TRAVIS_BUILD_DIR/application-server/test/ && pytest --cov=./
-  - codecov
-  #android app
-  - cd $TRAVIS_BUILD_DIR/android-app/
-  - ./gradlew build jacocoTestReport assembleAndroidTest
-  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell setprop dalvik.vm.dexopt-flags v=n,o=v
-  - ./gradlew connectedCheck
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+matrix:
+  include:
+    - language: python
+      python: 3.6
+      services:
+        - mongodb
+      before_install:
+        - pip install pytest pytest-cov
+        - pip install codecov
+      install:
+        - cd $TRAVIS_BUILD_DIR/application-server/ && pip install -r requirements.txt
+      script:
+        - cd $TRAVIS_BUILD_DIR/application-server/
+        - export MONGO_URI=mongodb://localhost:27017/appserverdb
+        - python app.py &
+        - cd $TRAVIS_BUILD_DIR/application-server/test/ && pytest --cov=./
+        - codecov
+
+    - language: android
+      jdk: oraclejdk8
+      env:
+        global:
+          - ANDROID_TARGET=android-15
+          - ANDROID_ABI=armeabi-v7a
+      android:
+        components:
+        - tools
+        - platform-tools
+        - build-tools-26.0.2
+        - android-26
+        - extra-android-m2repository
+        - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
+      script:
+        - cd $TRAVIS_BUILD_DIR/android-app/
+        - ./gradlew build jacocoTestReport assembleAndroidTest
+        - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+        - emulator -avd test -no-skin -no-audio -no-window &
+        - android-wait-for-emulator
+        - adb shell setprop dalvik.vm.dexopt-flags v=n,o=v
+        - ./gradlew connectedCheck
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+
+    - language: node_js
+      node_js:
+        - "8.10"
+      install:
+        - cd $TRAVIS_BUILD_DIR/shared-server/ && npm install
+        - npm install -g istanbul
+        - npm install -g codecov
+      script:
+        - cd $TRAVIS_BUILD_DIR/shared-server/ && npm test
+        - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec
+        - codecov
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - language: android
       jdk: oraclejdk8
       env:
-        - ANDROID_TARGET=android-26
+        - ANDROID_TARGET=android-22
         - ANDROID_ABI=armeabi-v7a
       android:
         components:
@@ -27,6 +27,7 @@ matrix:
         - platform-tools
         - build-tools-26.0.2
         - android-26
+        - android-22
         - extra-android-m2repository
         - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ matrix:
     - language: android
       jdk: oraclejdk8
       env:
-        global:
-          - ANDROID_TARGET=android-15
-          - ANDROID_ABI=armeabi-v7a
+        - ANDROID_TARGET=android-15
+        - ANDROID_ABI=armeabi-v7a
       android:
         components:
         - tools

--- a/android-app/app/build.gradle
+++ b/android-app/app/build.gradle
@@ -19,6 +19,9 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {
@@ -31,3 +34,15 @@ dependencies {
     implementation 'com.android.support:cardview-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
 }
+
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+    }
+}
+apply plugin: 'jacoco-android'


### PR DESCRIPTION
Adds travis building and coverage to android app. This does not run what are called instrumental tests (those that require emulator). These are mostly UI stuff, so a proper model could be tested anyway.